### PR TITLE
Type doc strings

### DIFF
--- a/graphql/countries_trevorblades_com.graphql
+++ b/graphql/countries_trevorblades_com.graphql
@@ -1,3 +1,6 @@
+"""
+fields for fetching information from tables "sz_continents", "sz_continent", "sz_countries", "sz_country", "sz_CountryWithGDP", "sz_languages", "sz_language".
+"""
 type Query {
   sz_continents(filter: sz_ContinentFilterInput): [sz_Continent!]!
     @graphql(
@@ -51,12 +54,18 @@ input sz_StringQueryOperatorInput {
   glob: String
 }
 
+"""
+fields for all continent information of type sz_Continent
+"""
 type sz_Continent {
   code: ID!
   name: String!
   countries: [sz_Country!]!
 }
 
+"""
+fields for all country information of type sz_Country
+"""
 type sz_Country {
   code: ID!
   name: String!
@@ -71,6 +80,9 @@ type sz_Country {
   states: [sz_State!]!
 }
 
+"""
+fields for a country with GDP information of type sz_CountryWithGDP
+"""
 type sz_CountryWithGDP {
   code: ID!
   name: String!
@@ -86,6 +98,9 @@ type sz_CountryWithGDP {
   GDP: Int
 }
 
+"""
+fields for all language information of type sz_language
+"""
 type sz_Language {
   code: ID!
   name: String
@@ -93,18 +108,27 @@ type sz_Language {
   rtl: Boolean!
 }
 
+"""
+fields for all state information of type sz_state
+"""
 type sz_State {
   code: String
   name: String!
   country: sz_Country!
 }
 
+"""
+fields for all country filter input information of type sz_CountryFilterInput
+"""
 input sz_CountryFilterInput {
   code: sz_StringQueryOperatorInput
   currency: sz_StringQueryOperatorInput
   continent: sz_StringQueryOperatorInput
 }
 
+"""
+field for all language filter input information of type sz_LanguageFilterInput
+"""
 input sz_LanguageFilterInput {
   code: sz_StringQueryOperatorInput
 }

--- a/graphql/countries_trevorblades_com.graphql
+++ b/graphql/countries_trevorblades_com.graphql
@@ -99,7 +99,7 @@ type sz_CountryWithGDP {
 }
 
 """
-fields for all language information of type sz_language
+fields for all language information of type sz_Language
 """
 type sz_Language {
   code: ID!
@@ -109,7 +109,7 @@ type sz_Language {
 }
 
 """
-fields for all state information of type sz_state
+fields for all state information of type sz_State
 """
 type sz_State {
   code: String
@@ -117,18 +117,12 @@ type sz_State {
   country: sz_Country!
 }
 
-"""
-fields for all country filter input information of type sz_CountryFilterInput
-"""
 input sz_CountryFilterInput {
   code: sz_StringQueryOperatorInput
   currency: sz_StringQueryOperatorInput
   continent: sz_StringQueryOperatorInput
 }
 
-"""
-field for all language filter input information of type sz_LanguageFilterInput
-"""
 input sz_LanguageFilterInput {
   code: sz_StringQueryOperatorInput
 }

--- a/mysql/mysql.graphql
+++ b/mysql/mysql.graphql
@@ -1,3 +1,6 @@
+"""
+fields for all countries of type Countries
+"""
 type Countries {
   GDP: Int
   code: ID
@@ -5,6 +8,9 @@ type Countries {
   sz_Country: sz_Country @materializer(query: "sz_country" arguments: [{ name: "code" field: "code"}])
 }
 
+"""
+fields for fetching information from table "Countries"
+"""
 type Query {
   getCountriesList: [Countries]
     @dbquery(type: "mysql", table: "countries", configuration: "mysql_config")


### PR DESCRIPTION
## Linked Issue
#3

## Description
This PR includes the addition of doc strings for "types" in `countries_trevorblades_com` and `mysql.graphql`.

## Methodology
Previously, there were no docs for the GraphQL types in the above files. Thus, doc strings for the "types" were added for added. At the opening of this PR, changes were correctly rendering on the app in the "Docs" section.